### PR TITLE
add capability to do incremental hash digests

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -26,6 +26,18 @@ Compute a Keccak256 Hash
   >>> keccak(b'')
   b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p"
 
+
+You may also compute hashes incrementally
+
+.. doctest::
+
+  >>> from eth_hash.auto import keccak
+  >>> digest = keccak.Digest(b'part-a')
+  >>> digest.update(b'part-b')
+  >>> digest.digest()
+  b'6\x91l\xdd50\xd6[\x7f\xf9B\xff\xc9SW\x98\xc3\xaal\xd9\xde\xdd6I\xb7\x91\x9e\xf4`pl\x08'
+
+
 Select one of many installed backends
 ---------------------------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -37,6 +37,20 @@ You may also compute hashes incrementally
   >>> digest.digest()
   b'6\x91l\xdd50\xd6[\x7f\xf9B\xff\xc9SW\x98\xc3\xaal\xd9\xde\xdd6I\xb7\x91\x9e\xf4`pl\x08'
 
+Digests may be copied as well.
+
+.. doctest::
+
+  >>> from eth_hash.auto import keccak
+  >>> digest = keccak.Digest(b'part-a')
+  >>> digest_copy = digest.copy()
+  >>> digest.update(b'part-b')
+  >>> digest.digest()
+  b'6\x91l\xdd50\xd6[\x7f\xf9B\xff\xc9SW\x98\xc3\xaal\xd9\xde\xdd6I\xb7\x91\x9e\xf4`pl\x08'
+  >>> digest_copy.update(b'part-c')
+  >>> digest_copy.digest()
+  b'\xffcy45\xea\xdd\xdf\x8e(\x1c\xfcF\xf3\xd4\xa1S\x0f\xdf\xd8\x01!\xb2(\xe1\xc7\xc6\xa3\x08\xc3\n\x0b'
+
 
 Select one of many installed backends
 ---------------------------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,23 +32,23 @@ You may also compute hashes incrementally
 .. doctest::
 
   >>> from eth_hash.auto import keccak
-  >>> digest = keccak.Digest(b'part-a')
-  >>> digest.update(b'part-b')
-  >>> digest.digest()
+  >>> preimage = keccak.new(b'part-a')
+  >>> preimage.update(b'part-b')
+  >>> preimage.digest()
   b'6\x91l\xdd50\xd6[\x7f\xf9B\xff\xc9SW\x98\xc3\xaal\xd9\xde\xdd6I\xb7\x91\x9e\xf4`pl\x08'
 
-Digests may be copied as well.
+The preimage object returned may be copied as well.
 
 .. doctest::
 
   >>> from eth_hash.auto import keccak
-  >>> digest = keccak.Digest(b'part-a')
-  >>> digest_copy = digest.copy()
-  >>> digest.update(b'part-b')
-  >>> digest.digest()
+  >>> preimage = keccak.new(b'part-a')
+  >>> preimage_copy = preimage.copy()
+  >>> preimage.update(b'part-b')
+  >>> preimage.digest()
   b'6\x91l\xdd50\xd6[\x7f\xf9B\xff\xc9SW\x98\xc3\xaal\xd9\xde\xdd6I\xb7\x91\x9e\xf4`pl\x08'
-  >>> digest_copy.update(b'part-c')
-  >>> digest_copy.digest()
+  >>> preimage_copy.update(b'part-c')
+  >>> preimage_copy.digest()
   b'\xffcy45\xea\xdd\xdf\x8e(\x1c\xfcF\xf3\xd4\xa1S\x0f\xdf\xd8\x01!\xb2(\xe1\xc7\xc6\xa3\x08\xc3\n\x0b'
 
 

--- a/eth_hash/backends/pysha3.py
+++ b/eth_hash/backends/pysha3.py
@@ -1,7 +1,7 @@
 from sha3 import (
-    keccak_256,
+    keccak_256 as _keccak_256,
 )
 
 
 def keccak256(prehash: bytes) -> bytes:
-    return keccak_256(prehash).digest()
+    return _keccak_256(prehash).digest()

--- a/eth_hash/main.py
+++ b/eth_hash/main.py
@@ -13,14 +13,12 @@ class Keccak256:
     def Digest(self, part):
         if not isinstance(part, bytes):
             raise TypeError("Can only compute the hash of a `bytes` value, not %r" % part)
-        digest = Digest(part, keccak_fn=self.hasher)
-        digest.update(part)
-        return digest
+        return Digest(part, keccak_fn=self.hasher)
 
 
 class Digest:
-    def __init__(self, part, keccak_fn):
-        self.preimage_parts = []
+    def __init__(self, *parts, keccak_fn):
+        self.preimage_parts = list(parts)
         self.keccak_fn = keccak_fn
 
     def update(self, part):
@@ -30,3 +28,7 @@ class Digest:
 
     def digest(self):
         return self.keccak_fn(b''.join(self.preimage_parts))
+
+    def copy(self):
+        digest = type(self)(*self.preimage_parts, keccak_fn=self.keccak_fn)
+        return digest

--- a/eth_hash/main.py
+++ b/eth_hash/main.py
@@ -2,10 +2,31 @@ class Keccak256:
     def __init__(self, backend):
         self.hasher = backend.keccak256
 
-        assert self.hasher(b'') == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p"  # noqa: E501
+        assert self.hasher(b'') == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p"  # noqa: E501
 
     def __call__(self, preimage):
         if not isinstance(preimage, bytes):
             raise TypeError("Can only compute the hash of a `bytes` value, not %r" % preimage)
 
         return self.hasher(preimage)
+
+    def Digest(self, part):
+        if not isinstance(part, bytes):
+            raise TypeError("Can only compute the hash of a `bytes` value, not %r" % part)
+        digest = Digest(part, keccak_fn=self.hasher)
+        digest.update(part)
+        return digest
+
+
+class Digest:
+    def __init__(self, part, keccak_fn):
+        self.preimage_parts = []
+        self.keccak_fn = keccak_fn
+
+    def update(self, part):
+        if not isinstance(part, bytes):
+            raise TypeError("Can only compute the hash of a `bytes` value, not %r" % part)
+        self.preimage_parts.append(part)
+
+    def digest(self):
+        return self.keccak_fn(b''.join(self.preimage_parts))

--- a/eth_hash/main.py
+++ b/eth_hash/main.py
@@ -10,13 +10,13 @@ class Keccak256:
 
         return self.hasher(preimage)
 
-    def Digest(self, part):
+    def new(self, part):
         if not isinstance(part, bytes):
             raise TypeError("Can only compute the hash of a `bytes` value, not %r" % part)
-        return Digest(part, keccak_fn=self.hasher)
+        return PreImage(part, keccak_fn=self.hasher)
 
 
-class Digest:
+class PreImage:
     def __init__(self, *parts, keccak_fn):
         self.preimage_parts = list(parts)
         self.keccak_fn = keccak_fn

--- a/tests/backends/test_results.py
+++ b/tests/backends/test_results.py
@@ -41,18 +41,18 @@ def test_keccak_256(keccak, prehash, expected_result):
         ),
     ),
 )
-def test_keccak_256_digest(keccak, parts, expected_result):
-    digest = keccak.Digest(parts[0])
+def test_keccak_256_preimage(keccak, parts, expected_result):
+    preimage = keccak.new(parts[0])
     for part in parts[1:]:
-        digest.update(part)
-    assert digest.digest() == expected_result
+        preimage.update(part)
+    assert preimage.digest() == expected_result
 
 
-def test_copy_keccak_256_digest(keccak):
-    digest_origin = keccak.Digest(b'')
-    digest_copy = digest_origin.copy()
+def test_copy_keccak_256_preimage(keccak):
+    preimage_origin = keccak.new(b'')
+    preimage_copy = preimage_origin.copy()
 
-    digest_origin.update(b'arsttsra')
+    preimage_origin.update(b'arsttsra')
 
-    assert digest_origin.digest() == b"\xb1\xf3T\xb2\x8f\xf2\x84R\xd6\xb9\xd6\x1fA\x06\x1b\xbe\x82\xbe\xb1\xfc\x98\xf33d\xa8\x05\x8d\x1a]\x16M\x05"  # noqa: E501
-    assert digest_copy.digest() == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p"  # noqa: E501
+    assert preimage_origin.digest() == b"\xb1\xf3T\xb2\x8f\xf2\x84R\xd6\xb9\xd6\x1fA\x06\x1b\xbe\x82\xbe\xb1\xfc\x98\xf33d\xa8\x05\x8d\x1a]\x16M\x05"  # noqa: E501
+    assert preimage_copy.digest() == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p"  # noqa: E501

--- a/tests/backends/test_results.py
+++ b/tests/backends/test_results.py
@@ -46,3 +46,13 @@ def test_keccak_256_digest(keccak, parts, expected_result):
     for part in parts[1:]:
         digest.update(part)
     assert digest.digest() == expected_result
+
+
+def test_copy_keccak_256_digest(keccak):
+    digest_origin = keccak.Digest(b'')
+    digest_copy = digest_origin.copy()
+
+    digest_origin.update(b'arsttsra')
+
+    assert digest_origin.digest() == b"\xb1\xf3T\xb2\x8f\xf2\x84R\xd6\xb9\xd6\x1fA\x06\x1b\xbe\x82\xbe\xb1\xfc\x98\xf33d\xa8\x05\x8d\x1a]\x16M\x05"  # noqa: E501
+    assert digest_copy.digest() == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p"  # noqa: E501

--- a/tests/backends/test_results.py
+++ b/tests/backends/test_results.py
@@ -16,9 +16,33 @@ def keccak_auto():
     (
         (
             b'',
-            b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p",  # noqa: E501
+            b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p",  # noqa: E501
         ),
     ),
 )
 def test_keccak_256(keccak, prehash, expected_result):
     assert keccak(prehash) == expected_result
+
+
+@pytest.mark.parametrize(
+    'parts, expected_result',
+    (
+        (
+            [b''],
+            b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p",  # noqa: E501
+        ),
+        (
+            [b'', b'', b''],
+            b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p",  # noqa: E501
+        ),
+        (
+            [b'arst', b'tsra'],
+            b"\xb1\xf3T\xb2\x8f\xf2\x84R\xd6\xb9\xd6\x1fA\x06\x1b\xbe\x82\xbe\xb1\xfc\x98\xf33d\xa8\x05\x8d\x1a]\x16M\x05",  # noqa: E501
+        ),
+    ),
+)
+def test_keccak_256_digest(keccak, parts, expected_result):
+    digest = keccak.Digest(parts[0])
+    for part in parts[1:]:
+        digest.update(part)
+    assert digest.digest() == expected_result


### PR DESCRIPTION
## What was wrong?

The p2p code in py-evm needs to do incremental keccak256 hashes.  It was previously hardwired to use the `pysha3` keccak function.  This doesn't fit with our choice to make the function swappable.

## How was it fixed?

Added a new API to the `Keccak256` object which returns a `Digest` object which can be updated with additional bytes and then `digest()` to compute the full hash.

#### Cute Animal Picture

![pygmy-sloth-mangroves_71212](https://user-images.githubusercontent.com/824194/36450096-183d826a-164a-11e8-9e43-dabad325dd4c.jpg)
