### PR TITLE
Update pycryptodome and remove bytes conversion

### DIFF
--- a/eth_hash/main.py
+++ b/eth_hash/main.py
@@ -10,7 +10,7 @@ class Keccak256:
                 "Can only compute the hash of `bytes` or `bytearray` values, not %r" % preimage
             )
 
-        return self.hasher(bytes(preimage))
+        return self.hasher(preimage)
 
     def new(self, part):
         if not isinstance(part, (bytes, bytearray)):
@@ -30,7 +30,7 @@ class PreImage:
             raise TypeError(
                 "Can only compute the hash of `bytes` or `bytearray` values, not %r" % part
             )
-        self.preimage_parts.append(bytes(part))
+        self.preimage_parts.append(part)
 
     def digest(self):
         return self.keccak_fn(b''.join(self.preimage_parts))

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require={
     ],
     # optional backends:
     'pycryptodome': [
-        "pycryptodome>=3.4.6,<4",
+        "pycryptodome>=3.5.1,<4",
     ],
     'pysha3': [
         "pysha3>=1.0.0,<2.0.0",


### PR DESCRIPTION
## What was wrong?

In 07ec01011a227f12c8cf45754c74fdbbd8134227 I added bytes conversions in order to support bytearrays with the pycryptodome backend. The upstream now supports bytearrays and this can be removed.

## How was it fixed?

Update to newer pycryptodome with bytearray support.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iur/?f=1&image_host=https%3A%2F%2Fs-media-cache-ak0.pinimg.com%2F736x%2F59%2F77%2Fae%2F5977ae13e5ff252f724a52f9c38fdb86.jpg&u=https://i.pinimg.com/736x/59/77/ae/5977ae13e5ff252f724a52f9c38fdb86.jpg)
