### PR TITLE
Require minimum python version during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     install_requires=[
     ],
     setup_requires=['setuptools-markdown'],
+    python_requires='>=3.5, <4',
     extras_require=extras_require,
     py_modules=['eth_hash'],
     license="MIT",


### PR DESCRIPTION
## What was wrong?

Improves the error message for situations like Issue #14 

## How was it fixed?

Add minimum python version to setup.py. pip 9+ will enforce and give a cleaner error message.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/6d/6b/90/6d6b90bd6ab9341f2670db535ed2cda6.jpg)