### PR TITLE
Include tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft tests


### PR DESCRIPTION
## What was wrong?
The `tests/` directory is missing from the tarball released on PyPI.
Having the tests is useful for downstream distributions to test if the package works correctly with their build recipe. Also, it provides a way to test if the dependencies as they are packaged by the distribution are compatible.

## How was it fixed?
Add `MANIFEST.in`.