### PR TITLE
set `pycryptodome` version to `3.6.6` to fix a recently discovered vulnerability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require={
     ],
     # optional backends:
     'pycryptodome': [
-        "pycryptodome>=3.5.1,<4",
+        "pycryptodome>=3.6.6,<4",
     ],
     'pysha3': [
         "pysha3>=1.0.0,<2.0.0",


### PR DESCRIPTION
## What was wrong?
Recently a [vulnerability was discovered in pycryptodome](https://github.com/Legrandin/pycryptodome/issues/198). 


## How was it fixed?
set `pycryptodome` version to `3.6.6` to fix a recently discovered vulnerability.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSaTshpBVjGCaDgWJaizAumF6twtMYFv0Sw5_Gkaq_iT5DpQ2Oj)
