### PR TITLE
Actually export type annotations

### DIFF
--- a/.project-template/fill_template_vars.sh
+++ b/.project-template/fill_template_vars.sh
@@ -47,3 +47,4 @@ _replace "s/<SHORT_DESCRIPTION>/$SHORT_DESCRIPTION/g"
 
 mkdir -p "$PROJECT_ROOT/$MODULE_NAME"
 touch "$PROJECT_ROOT/$MODULE_NAME/__init__.py"
+touch "$PROJECT_ROOT/$MODULE_NAME/py.typed"

--- a/newsfragments/28.bugfix.rst
+++ b/newsfragments/28.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix to export type annotations


### PR DESCRIPTION
## What was wrong?

Fixes #28

## How was it fixed?

Merge in template change, to test that `eth_hash/py.typed` is properly created.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-hash.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/00/19/23/001923598481eb1590e7d484c68f8aa7.jpg)
