### PR TITLE
Add first Github Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: ['3.6', '3.7', '3.8']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python for ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: python -m pip install -e .[dev]
+      - name: Run tests for Python-${{ matrix.python-version }} with ${{ matrix.os }}
+        run: python -m tox

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist=
     py{35,36,37}-backend-pysha3
     lint
     docs
+isolated_build=True
+skip_missing_interpreters=True
 
 [isort]
 combine_as_imports=True


### PR DESCRIPTION
Github Actions was introduced a couple of years ago and it's now the de-facto tool for building, testing, and publishing Open Souce projects hosted in Github.

This PR introduces a first and introductory pipeline to run all tests upon every push and pull PR creation.

Some important notes:

- I wanted to add support to Python 3.9, but there's an MYPY error and I wanted this pipeline to pass. Maybe after the issue is fixed (in another PR), 3.9 can be added.
- A also added configuration to spin the tests in Linux, macOS, and Windows runners. That's a feature not implemented in the current pipeline.
- When Python 3.5 was deprecated one year ago and Github Actions no longer has runners for it. So I had to leave it behind. Consider officially drop support to it.
- Note that this pipeline only runs the tox tests. If accepted, another workflow to build documentation and publish artifacts can be made.