### PR TITLE
Just initialize auto backend once

### DIFF
--- a/eth_hash/main.py
+++ b/eth_hash/main.py
@@ -22,15 +22,18 @@ class Keccak256:
         This is a bit of a hacky way to minimize overhead on hash calls after
         this first one.
         """
+        # Execute directly before saving method, to let any side-effects settle (see AutoBackend)
+        result = self._backend.keccak256(in_data)
         new_hasher = self._backend.keccak256
         assert new_hasher(b'') == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p"  # noqa: E501
         self.hasher = new_hasher
-        return new_hasher(in_data)
+        return result
 
     def _preimage_first_run(self, in_data: Union[bytearray, bytes]) -> PreImageAPI:
-        new_preimage = self._backend.preimage
-        self.preimage = new_preimage
-        return new_preimage(in_data)
+        # Execute directly before saving method, to let any side-effects settle (see AutoBackend)
+        result = self._backend.preimage(in_data)
+        self.preimage = self._backend.preimage
+        return result
 
     def __call__(self, preimage: Union[bytearray, bytes]) -> bytes:
         if not isinstance(preimage, (bytearray, bytes)):

--- a/newsfragments/36.performance.rst
+++ b/newsfragments/36.performance.rst
@@ -1,0 +1,1 @@
+Keccak backend was initialized every time it was called. Now it's initialized only the first time it's called.


### PR DESCRIPTION
## What was wrong?

Issue #35

## How was it fixed?

Autobackend was initialized every time it was called. Just init it once when object is created.

## Previous results

```
eth_hash 10.747742728999583
web3 14.371859122999012
cryptodome 7.886241019998124
pysha3 0.6233324849999917
```

When setting `ETH_HASH_BACKEND="pysha3"`:
```
eth_hash 6.742922992998501
web3 10.079077139998844
```

## Results after PR

```
eth_hash 4.656213931999446
cryptodome 7.79646546100048
pysha3 0.6171151390008163
```

When setting ETH_HASH_BACKEND="pysha3"

```
eth_hash 0.8036113110010774
cryptodome 7.874447432999659
pysha3 0.6161410700005945
```

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-hash.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://us.123rf.com/450wm/verastuchelova/verastuchelova1610/verastuchelova161000159/64997855-poco-h%C3%A1mster-phodopus-phodopus.jpg?ver=6)
