### PR TITLE
Update Manifest.in to prune venv files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,5 @@ graft tests
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+
+prune venv*

--- a/newsfragments/38.internal.rst
+++ b/newsfragments/38.internal.rst
@@ -1,0 +1,1 @@
+Prune ``venv`` files from the release via MANIFEST.in


### PR DESCRIPTION
## What was wrong?

When I was releasing, noticed that `venv` files were getting included. Once this release is out, I'll go through and update other odds and ends - pull in the project template, and update to modern python support. 


## How was it fixed?

Added the prune command to `MANIFEST.in`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-hash.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://d2r8r0qhs4bt8m.cloudfront.net/wp-content/uploads/2019/10/18163426/desktop-1412887008.jpg)
