### PR TITLE
feat: use pysha3 by default

### DIFF
--- a/eth_hash/backends/__init__.py
+++ b/eth_hash/backends/__init__.py
@@ -9,6 +9,6 @@ See :ref:`Choose a hashing backend` for more.
 """
 
 SUPPORTED_BACKENDS = [
-    "pycryptodome",  # prefer this over pysha3, for pypy3 support
     "pysha3",
+    "pycryptodome",
 ]

--- a/newsfragments/42.performance.rst
+++ b/newsfragments/42.performance.rst
@@ -1,0 +1,1 @@
+Prefer pysha3 backend by default


### PR DESCRIPTION
## What was wrong?

see https://github.com/ethereum/eth-hash/issues/35 for rationale

fixes #42

## How was it fixed?

reordered the default list, eth-hash already checks if the package is installed.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-hash.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![fast-rabbit-run](https://user-images.githubusercontent.com/4562643/178882964-75af005e-8a1c-43a7-a888-a68651444ec5.jpeg)

