### PR TITLE
feat: add entrypoint

### DIFF
--- a/eth_hash/auto.py
+++ b/eth_hash/auto.py
@@ -1,3 +1,5 @@
+import sys
+
 from eth_hash.backends.auto import (
     AutoBackend,
 )
@@ -6,3 +8,7 @@ from eth_hash.main import (
 )
 
 keccak = Keccak256(AutoBackend())
+
+
+def main():
+    print(keccak(sys.argv[1].encode()))

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,11 @@ setup(
     keywords="ethereum",
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_data={"eth_hash": ["py.typed"]},
+    entry_points={
+            'console_scripts': [
+                'eth-hash = eth_hash.auto:main',
+            ],
+        },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
I was looking for the easiest and fastest way to hash a string. I also understand this is a library so maybe this PR should instead go to [eth-utils](https://github.com/ethereum/eth-utils). Let me know what you think.

The PR intention is to be able to quickly hash something without having to opening a interactive Python console. Using [console scripts](https://packaging.python.org/en/latest/specifications/entry-points/) and in this case I had to add a main function to cast the incoming string.

Note: this PR only hashes the first given argument, in case you need to send multiple strings, I would need to update the function.

### How to test

``` sh
$ pip install -e .[dev]
$ eth-hash "Hello World"
b'Y/\xa7C\x88\x9f\xc7\xf9*\xc2\xa3{\xb1\xf5\xba\x1d\xaf*\\\x84t\x1c\xa0\xe0\x06\x1d$:.g\x07\xba'
```

I could go further and make it more complicated, adding type checks, encoding options, a CLI library, etc. But need to know if this feature is desired in the first place.