### PR TITLE
bump docs dependencies, remove unused

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,5 @@
+version: 2
+
+python:
+  install:
+  - requirements: requirements-docs.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinx_rtd_theme",
 ]
 
 suppress_warnings = ["autosectionlabel.*"]

--- a/newsfragments/48.internal.rst
+++ b/newsfragments/48.internal.rst
@@ -1,0 +1,1 @@
+remove unused docs deps, bump version of remaining

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,9 @@ extras_require = {
         "black>=22.0,<23",
     ],
     "doc": [
-        "Sphinx>=5.0.0,<6",
-        "sphinx_rtd_theme>=0.1.9,<1",
+        "Sphinx>=5.0.0",
+        "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
-        "jinja2>=3.0.0,<3.1.0",  # jinja2<3.0 or >=3.1.0 cause doc build failures.
     ],
     "dev": [
         "bumpversion>=0.5.3,<1",

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ extras=
     docs: pysha3
     pycryptodome: pycryptodome
     pysha3: pysha3
-whitelist_externals=make
+allowlist_externals=make
 
 [common-lint]
 # mypy needs cryptodome installed to infer types


### PR DESCRIPTION
## What was wrong?

Docs dependencies can be bumped and unnecessary ones removed

## How was it fixed?

Bumped and removed, plus tox whitelist -> allowlist while I'm here.

### To-Do

[//]: # (See: https://eth-hash.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-hash/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/227622927-99241681-adbb-47b9-bd9d-92af2fffdac2.png)
