### PR TITLE
Modify path to use Crypto and Cryptodome

### DIFF
--- a/eth_hash/backends/pycryptodome.py
+++ b/eth_hash/backends/pycryptodome.py
@@ -3,9 +3,20 @@ from typing import (
     cast,
 )
 
-from Crypto.Hash import (
-    keccak,
-)
+try:
+    from Cryptodome.Hash import (
+        keccak,
+    )
+except ImportError:
+    try:
+        from Crypto.Hash import (
+            keccak,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "Could not import either 'Cryptodome' or 'Crypto' namespace. "
+            "Please install pycryptodome package."
+        ) from exc
 
 from eth_hash.abc import (
     BackendAPI,

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ extras_require = {
     "pycryptodome": [
         "pycryptodome>=3.6.6,<4",
     ],
+    "pycryptodomex": [
+        "pycryptodomex>=3.6.6,<4",
+    ],
     "pysha3": [
         "pysha3>=1.0.0,<2.0.0;python_version<'3.9'",
         "safe-pysha3>=1.0.0;python_version>='3.9'",

--- a/tests/core/test_import_and_version.py
+++ b/tests/core/test_import_and_version.py
@@ -25,7 +25,18 @@ def test_import_auto_empty_crash(monkeypatch):
         keccak,
     )
 
-    with mock.patch.dict("sys.modules", {"sha3": None, "Crypto.Hash": None}):
+    clean_module("eth_hash.backends.pycryptodome")
+    clean_module("eth_hash.backends.pysha3")
+
+    with mock.patch.dict(
+        "sys.modules",
+        {
+            "sha3": None,
+            "Crypto": None,
+            "Cryptodome": None,
+            "eth_hash.backends": mock.MagicMock(),
+        },
+    ):
         with pytest.raises(
             ImportError, match="None of these hashing backends are installed"
         ):
@@ -53,7 +64,18 @@ def test_load_by_env(monkeypatch, backend):
     )
 
     monkeypatch.setenv("ETH_HASH_BACKEND", backend)
-    with mock.patch.dict("sys.modules", {"sha3": None, "Crypto.Hash": None}):
+    clean_module("eth_hash.backends.pycryptodome")
+    clean_module("eth_hash.backends.pysha3")
+
+    with mock.patch.dict(
+        "sys.modules",
+        {
+            "sha3": None,
+            "Crypto": None,
+            "Cryptodome": None,
+            "eth_hash.backends": mock.MagicMock(),
+        },
+    ):
         with pytest.raises(ImportError) as excinfo:
             keccak(b"triggered")
     expected_msg = (


### PR DESCRIPTION
On Debian, the expected path is Cryptodome. I made a small adjustment so that the scripts use both Crypto and Cryptodome paths.

Please consider carefully evaluating this change and accepting this PR if you are interested. If there is anything wrong with it, let me know.

Regards,